### PR TITLE
Remove deepseek from ollama models

### DIFF
--- a/manifests/infrastructure/ollama/release.yaml
+++ b/manifests/infrastructure/ollama/release.yaml
@@ -53,11 +53,9 @@ spec:
           enabled: false
       models:
         pull:
-        - deepseek-r1:1.5b
         - qwen3:8b
         - gemma3:4b
         run:
-        - deepseek-r1:1.5b
         - qwen3:8b
         - gemma3:4b
     service:


### PR DESCRIPTION
## Summary
- remove the deepseek model from the list of ollama models

## Testing
- `grep -R "deepseek" -n || true`
- *Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.*

------
https://chatgpt.com/codex/tasks/task_e_688c7b58e37c832687f08a1498b8b63d